### PR TITLE
Add Aegis-BPF to Security section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -350,6 +350,7 @@ If you are new to eBPF, you may want to try the links described as "introduction
 - [Bombini](https://github.com/bombinisecurity/bombini) - An eBPF-based security agent written entirely in Rust using the [Aya](https://github.com/aya-rs/aya) library and built on LSM (Linux Security Module) BPF hooks.
 - [owLSM](https://github.com/Cybereason-Public/owLSM) - Open source agent that implements a stateful Sigma rules engine focused on monitoring and prevention using eBPF LSM.
 - [Inner Warden](https://github.com/InnerWarden/innerwarden) - A self-defending security agent for Linux and macOS that uses eBPF with 22 kernel hooks (tracepoints, kprobes, LSM, XDP) via the Aya library for real-time threat detection, automated response, and AI-powered triage.
+- [Aegis-BPF](https://github.com/ErenAri/Aegis-BPF) - Enforcement-first Linux runtime security agent using eBPF LSM to deny selected file and network operations before syscall completion, with cgroup-scoped policy, Prometheus metrics, and Kubernetes deployment support.
 
 ### Linux Scheduler
 


### PR DESCRIPTION
This PR adds Aegis-BPF to the Security section.

Aegis-BPF is an open-source Linux runtime security project built around eBPF LSM. It focuses on enforcement-first policy decisions: denying selected file and network operations before syscall completion.

It fits this section because it uses eBPF LSM hooks for runtime policy enforcement, similar in category to other eBPF security projects listed here.

Repository:
https://github.com/ErenAri/Aegis-BPF